### PR TITLE
Change the way image data is stored

### DIFF
--- a/planetaryimage/cubefile.py
+++ b/planetaryimage/cubefile.py
@@ -43,6 +43,11 @@ class CubeFile(PlanetaryImage):
 
     SPECIAL_PIXELS = SPECIAL_PIXELS
 
+    def __init__(self, *args, **kwargs):
+        if 'memory_layout' not in kwargs:
+            kwargs['memory_layout'] = 'DISK'
+        super(CubeFile, self).__init__(*args, **kwargs)
+
     @property
     def tile_lines(self):
         """Number of lines per tile."""
@@ -103,6 +108,10 @@ class CubeFile(PlanetaryImage):
                     chunk_lines, chunk_samples = chunk.shape
                     chunk[:] = tile[:chunk_lines, :chunk_samples]
 
-        if self.bands == 1:
-            return data.squeeze()
-        return numpy.dstack((data))
+        if self.memory_layout == 'IMAGE':
+            if self.bands == 1:
+                return data.squeeze()
+            else:
+                return numpy.dstack((data))
+        else:
+            return data

--- a/planetaryimage/cubefile.py
+++ b/planetaryimage/cubefile.py
@@ -103,4 +103,6 @@ class CubeFile(PlanetaryImage):
                     chunk_lines, chunk_samples = chunk.shape
                     chunk[:] = tile[:chunk_lines, :chunk_samples]
 
-        return data
+        if self.bands == 1:
+            return data.squeeze()
+        return numpy.dstack((data))

--- a/planetaryimage/image.py
+++ b/planetaryimage/image.py
@@ -225,4 +225,7 @@ class PlanetaryImage(object):
 
     def _parse_band_sequential_data(self, stream):
         data = numpy.fromfile(stream, self.dtype, self.size)
-        return data.reshape(self.shape)
+        data = data.reshape(self.shape)
+        if self.bands == 1:
+            return data.squeeze()
+        return numpy.dstack((data))

--- a/planetaryimage/image.py
+++ b/planetaryimage/image.py
@@ -26,12 +26,15 @@ class PlanetaryImage(object):
         with open(filename, 'rb') as fp:
             return cls(fp, filename)
 
-    def __init__(self, stream, filename=None):
+    def __init__(self, stream, filename=None, memory_layout='DISK'):
         """Create an Image file.
 
         :param stream: file object to read as an image file
 
         :param filename: an optional filename to attach to the object
+
+        :param memory_layout: format of the data that is returned
+            supported values are "IMAGE" and "DISK"
         """
         if isinstance(stream, string_types):
             error_msg = (
@@ -42,6 +45,12 @@ class PlanetaryImage(object):
 
         #: The filename if given, otherwise none.
         self.filename = filename
+
+        if memory_layout not in ['IMAGE', 'DISK']:
+            raise ValueError('Unsupported memory_layout value.\
+                Expected "IMAGE" or "DISK"')
+
+        self.memory_layout = memory_layout
 
         #: The parsed label header in dictionary form.
         self.label = self._parse_label(stream)
@@ -226,6 +235,10 @@ class PlanetaryImage(object):
     def _parse_band_sequential_data(self, stream):
         data = numpy.fromfile(stream, self.dtype, self.size)
         data = data.reshape(self.shape)
-        if self.bands == 1:
-            return data.squeeze()
-        return numpy.dstack((data))
+        if self.memory_layout == 'IMAGE':
+            if self.bands == 1:
+                return data.squeeze()
+            else:
+                return numpy.dstack((data))
+        else:
+            return data

--- a/planetaryimage/pds3image.py
+++ b/planetaryimage/pds3image.py
@@ -32,6 +32,8 @@ class PDS3Image(PlanetaryImage):
     }
 
     def __init__(self, *args, **kwargs):
+        if 'memory_layout' not in kwargs:
+            kwargs['memory_layout'] = 'IMAGE'
         super(PDS3Image, self).__init__(*args, **kwargs)
 
     @property

--- a/tests/test_cubefile.py
+++ b/tests/test_cubefile.py
@@ -27,11 +27,11 @@ def test_cubefile():
     assert image.shape == (1, 90, 90)
     assert image.size == 8100
 
-    assert image.data.shape == (1, 90, 90)
+    assert image.data.shape == (90, 90)
     assert image.data.size == 8100
 
     expected = numpy.loadtxt(os.path.join(DATA_DIR, 'pattern.txt'), skiprows=2)
-    assert_almost_equal(image.data[0], expected)
+    assert_almost_equal(image.data, expected)
 
 
 def test_stream_error():

--- a/tests/test_cubefile.py
+++ b/tests/test_cubefile.py
@@ -3,13 +3,18 @@ import pytest
 import os
 import numpy
 from numpy.testing import assert_almost_equal
-from planetaryimage.cubefile import CubeFile
+from planetaryimage import CubeFile
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data/')
 
 
-def test_cubefile():
+@pytest.fixture
+def pattern_data():
+    return numpy.loadtxt(os.path.join(DATA_DIR, 'pattern.txt'), skiprows=2)
+
+
+def test_cubefile_labels():
     filename = os.path.join(DATA_DIR, 'pattern.cub')
     image = CubeFile.open(filename)
 
@@ -27,11 +32,25 @@ def test_cubefile():
     assert image.shape == (1, 90, 90)
     assert image.size == 8100
 
+
+def test_cubefile_disk_format(pattern_data):
+    filename = os.path.join(DATA_DIR, 'pattern.cub')
+    image = CubeFile.open(filename)
+
     assert image.data.shape == (1, 90, 90)
     assert image.data.size == 8100
 
-    expected = numpy.loadtxt(os.path.join(DATA_DIR, 'pattern.txt'), skiprows=2)
-    assert_almost_equal(image.data[0], expected)
+    assert_almost_equal(image.data[0], pattern_data)
+
+
+def test_cubefile_image_format(pattern_data):
+    filename = os.path.join(DATA_DIR, 'pattern.cub')
+    image = CubeFile(open(filename, 'rb'), memory_layout='IMAGE')
+
+    assert image.data.shape == (90, 90)
+    assert image.data.size == 8100
+
+    assert_almost_equal(image.data, pattern_data)
 
 
 def test_stream_error():

--- a/tests/test_cubefile.py
+++ b/tests/test_cubefile.py
@@ -27,11 +27,11 @@ def test_cubefile():
     assert image.shape == (1, 90, 90)
     assert image.size == 8100
 
-    assert image.data.shape == (90, 90)
+    assert image.data.shape == (1, 90, 90)
     assert image.data.size == 8100
 
     expected = numpy.loadtxt(os.path.join(DATA_DIR, 'pattern.txt'), skiprows=2)
-    assert_almost_equal(image.data, expected)
+    assert_almost_equal(image.data[0], expected)
 
 
 def test_stream_error():

--- a/tests/test_pds3file.py
+++ b/tests/test_pds3file.py
@@ -25,9 +25,9 @@ def test_pds3_1band_file():
     assert image.byte_order == '>'
     assert image.size == 100
 
-    assert image.data.shape == (1, 10, 10)
+    assert image.data.shape == (10, 10)
     assert image.data.size == 100
 
     expected = numpy.loadtxt(
-        os.path.join(DATA_DIR, 'pds3_1band.txt')).reshape(1, 10, 10)
+        os.path.join(DATA_DIR, 'pds3_1band.txt')).reshape(10, 10)
     assert_almost_equal(image.data, expected)

--- a/tests/test_pds3file.py
+++ b/tests/test_pds3file.py
@@ -3,14 +3,19 @@ import pytest
 import os
 import numpy
 from numpy.testing import assert_almost_equal
-from planetaryimage.pds3image import PDS3Image
+from planetaryimage import PDS3Image
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data/')
+filename = os.path.join(DATA_DIR, 'pds3_1band.IMG')
 
 
-def test_pds3_1band_file():
-    filename = os.path.join(DATA_DIR, 'pds3_1band.IMG')
+@pytest.fixture
+def pattern_data():
+    return numpy.loadtxt(os.path.join(DATA_DIR, 'pds3_1band.txt'))
+
+
+def test_pds3_1band_labels():
     image = PDS3Image.open(filename)
 
     assert image.filename == filename
@@ -25,9 +30,20 @@ def test_pds3_1band_file():
     assert image.byte_order == '>'
     assert image.size == 100
 
+
+def test_pds3_1band_image_format(pattern_data):
+    image = PDS3Image.open(filename)
+
     assert image.data.shape == (10, 10)
     assert image.data.size == 100
 
-    expected = numpy.loadtxt(
-        os.path.join(DATA_DIR, 'pds3_1band.txt')).reshape(10, 10)
-    assert_almost_equal(image.data, expected)
+    assert_almost_equal(image.data, pattern_data.reshape(10, 10))
+
+
+def test_pds3_1band_disk_format(pattern_data):
+    image = PDS3Image(open(filename, 'rb'), memory_layout='DISK')
+
+    assert image.data.shape == (1, 10, 10)
+    assert image.data.size == 100
+
+    assert_almost_equal(image.data[0], pattern_data)


### PR DESCRIPTION
#1 
1Band image returns (x, y)
Other images return (x, y, depth)

I just used the simplest method I could think of to change `_parse_tile_data` in `cubefile.py`. There could be better ways to do it.