### PR TITLE
pixel_type more explicit and extended

### DIFF
--- a/planetaryimage/image.py
+++ b/planetaryimage/image.py
@@ -60,6 +60,9 @@ class PlanetaryImage(object):
         #: A numpy array representing the image
         self.data = self._parse_data(stream)
 
+    def __repr__(self):
+        return self.filename
+
     @staticmethod
     def get_nested_dict(item, key_list):
         """Get value from nested dictionary using a key list. """
@@ -185,10 +188,8 @@ class PlanetaryImage(object):
 
     @property
     def byte_order(self):
-        """Byte order in numpy format('>', '<', '=').
-        Defaults to msb.
-        """
-        return '>'
+        """Byte order in numpy format('>', '<', '=')."""
+        raise NotImplementedError
 
     @property
     def data_filename(self):

--- a/planetaryimage/pds3image.py
+++ b/planetaryimage/pds3image.py
@@ -116,7 +116,7 @@ class PDS3Image(PlanetaryImage):
     def pixel_type(self):
         sample_type = self.label['IMAGE']['SAMPLE_TYPE']
         bits = self.label['IMAGE']['SAMPLE_BITS']
-        sample_bytes = str(bits/8)  # get bytes to match NumPy dtype expressions
+        sample_bytes = str(int(bits / 8))  # get bytes to match NumPy dtype expressions
 
         if sample_type in self.LSB_INTEGER_TYPES:
             return numpy.dtype('<i' + sample_bytes)

--- a/tests/test_pds3file.py
+++ b/tests/test_pds3file.py
@@ -24,7 +24,7 @@ def test_pds3_1band_labels():
     assert image.lines == 10
     assert image.samples == 10
     assert image.format == 'BAND_SEQUENTIAL'
-    assert image.pixel_type == numpy.dtype('int16')
+    #assert image.pixel_type == numpy.dtype('int16')
     assert image.dtype == numpy.dtype('>i2')
     assert image.start_byte == 640
     assert image.shape == (1, 10, 10)

--- a/tests/test_pds3file.py
+++ b/tests/test_pds3file.py
@@ -24,7 +24,7 @@ def test_pds3_1band_labels():
     assert image.lines == 10
     assert image.samples == 10
     assert image.format == 'BAND_SEQUENTIAL'
-    #assert image.pixel_type == numpy.dtype('int16')
+    assert image.pixel_type == numpy.dtype('>i2')
     assert image.dtype == numpy.dtype('>i2')
     assert image.start_byte == 640
     assert image.shape == (1, 10, 10)


### PR DESCRIPTION
I have extended pixel_type to include more types and to be more
explicit.  The handling of floats is not yet done.  It is also not
yet clear to me why an assert wasn't working for me.  I think the values
were equivalent, just not represented the same.

This isn't ready to be merged yet, I've just pushed it for review: @wtolson 

I am still trying to figure out how to express `IEEE_REAL` and `PC_REAL` in numpy.

refs #16 